### PR TITLE
Load the 'ext.apng' module only when necessary

### DIFF
--- a/APNG.php
+++ b/APNG.php
@@ -31,6 +31,7 @@ $wgHooks['ImageBeforeProduceHTML'][] = function($skin, $title, $file, &$framePar
 		$metadata = @unserialize($file->getMetadata());
 		$mimetype = $file->getMimeType();
 		if ( $mimetype == 'image/png' && isset($metadata['frameCount']) && $metadata['frameCount'] > 1 ) {
+			$skin->getOutput()->addModules( 'ext.apng' );
 			if ( !isset($frameParams['class']) ) {
 				$frameParams['class'] = 'apng';
 			} else {
@@ -38,10 +39,5 @@ $wgHooks['ImageBeforeProduceHTML'][] = function($skin, $title, $file, &$framePar
 			}
 		}
 	}
-	return true;
-};
-
-$wgHooks['BeforePageDisplay'][] = function($out, $skin){
-	$out->addModules( 'ext.apng' );
 	return true;
 };


### PR DESCRIPTION
instead of injecting it into every page
with the BeforePageDisplay hook
